### PR TITLE
DragonTea Unjumble

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
-  <component name="ProjectRootManager" version="2" project-jdk-name="Poetry (novelsave_sources)" project-jdk-type="Python SDK" />
+  <component name="ProjectRootManager" version="2" project-jdk-name="Python 3.9 (novelsave-sources-8uHVM6OD-py3.9)" project-jdk-type="Python SDK" />
 </project>

--- a/.idea/novelsave_sources.iml
+++ b/.idea/novelsave_sources.iml
@@ -2,7 +2,7 @@
 <module type="PYTHON_MODULE" version="4">
   <component name="NewModuleRootManager">
     <content url="file://$MODULE_DIR$" />
-    <orderEntry type="jdk" jdkName="Poetry (novelsave_sources)" jdkType="Python SDK" />
+    <orderEntry type="jdk" jdkName="Python 3.9 (novelsave-sources-8uHVM6OD-py3.9)" jdkType="Python SDK" />
     <orderEntry type="sourceFolder" forTests="false" />
   </component>
 </module>

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ A collection of novel sources offering varying amounts of scraping capability.
             <td align="center">en</td>
             <td>https://betwixtedbutterfly.com</td>
             <td align="center"></td>
-            <td align="center">2021-09-03</td>
+            <td align="center">2021-10-07</td>
         </tr>
         <tr>
             <td align="center">en</td>

--- a/novelsave_sources/sources/crawler.py
+++ b/novelsave_sources/sources/crawler.py
@@ -70,11 +70,10 @@ class Crawler(ABC):
         """
         :return: whether the text is black listed
         """
-        for pattern in self.blacklist_patterns:
-            if re.search(pattern, text, re.IGNORECASE):
-                return True
-
-        return False
+        return any(
+            re.search(pattern, text, re.IGNORECASE)
+            for pattern in self.blacklist_patterns
+        )
 
     def clean_contents(self, contents):
         if not contents:

--- a/novelsave_sources/sources/novel/betwixtedbutterfly.py
+++ b/novelsave_sources/sources/novel/betwixtedbutterfly.py
@@ -1,25 +1,22 @@
 import datetime
-from typing import List, Tuple
 
 from bs4 import BeautifulSoup
 
 from .source import Source
-from ...models import Chapter, Volume, Novel, Metadata
 from ...exceptions import ChapterException
+from ...models import Chapter, Volume, Novel, Metadata
 
 
 class BetwixtedButterfly(Source):
     name = 'Betwixted Butterfly'
     base_urls = ('https://betwixtedbutterfly.com',)
-    last_updated = datetime.date(2021, 9, 3)
+    last_updated = datetime.date(2021, 10, 7)
 
-    bad_tags = [
-        'noscript', 'script', 'iframe', 'form', 'img', 'ins',
-        'button', 'input', 'amp-auto-ads', 'pirate',
-        'nav', 'h1', 'h2',
-    ]
+    def __init__(self):
+        super(BetwixtedButterfly, self).__init__()
+        self.bad_tags += ['h1', 'h2']
 
-    def novel(self, url: str) -> Tuple[Novel, List[Chapter], List[Metadata]]:
+    def novel(self, url: str) -> Novel:
         soup = self.get_soup(url)
 
         details_parent, synopsis_parent, *_ = soup.select('.elementor-text-editor')
@@ -61,7 +58,10 @@ class BetwixtedButterfly(Source):
         elements = soup.select(".entry-inner section .elementor-element:not(.elementor-widget-button, "
                                ".elementor-column)")
         if elements:
-            content = BeautifulSoup(f'<div>{"".join([str(element) for element in elements])}</div>', 'lxml').select_one('div')
+            content = BeautifulSoup(
+                f'<div>{"".join(str(element) for element in elements)}</div>',
+                'lxml',
+            ).select_one('div')
         else:
             content = soup.select_one('.entry-inner')
 

--- a/novelsave_sources/sources/novel/dragontea.py
+++ b/novelsave_sources/sources/novel/dragontea.py
@@ -1,4 +1,6 @@
 import datetime
+from functools import lru_cache
+from typing import Dict
 
 from .source import Source
 from ...models import Chapter, Novel, Metadata
@@ -17,11 +19,13 @@ class DragonTea(Source):
         http_url = url.replace('https:', 'http:')
         soup = self.get_soup(http_url)
 
+        jumble_map = self.jumble_map()
+
         novel = Novel(
             title=soup.select_one('.post-title').text.strip(),
             author=soup.select_one('.author-content').text.strip(),
             thumbnail_url=self.to_absolute_url(soup.select_one('.summary_image img')['src'], url),
-            synopsis=[p.text.strip() for p in soup.select('.summary__content > p')],
+            synopsis=[self.reorder_text(jumble_map, p).text.strip() for p in soup.select('.summary__content > p')],
             url=url,
         )
 
@@ -58,17 +62,41 @@ class DragonTea(Source):
         return novel
 
     def chapter(self, chapter: Chapter):
-        soup = self.get_soup(chapter.url)
-
-        content = soup.select_one('.reading-content')
+        soup = self.get_soup(chapter.url.replace('https:', 'http:'))
 
         # text-left has a better collection of paragraphs...
         # however we are not taking any chances assuming its always there
-        text_left = content.select_one('.text-left')
-        if text_left:
-            content = text_left
+        content = soup.select_one('.text-left, .reading-content')
 
         self.clean_contents(content)
 
+        jumble_map = self.jumble_map()
+        for p in content.select('p'):
+            if not p.text.strip():
+                p.extract()
+                continue
+
+            self.reorder_text(jumble_map, p)
+
         chapter.title = soup.select_one('.breadcrumb > li.active').text.strip()
         chapter.paragraphs = str(content)
+
+    normal_char_set = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz'
+    jumble_char_set = 'ZYXWVUTSRQPONMLKJIHGFEDCBAzyxwvutsrqponmlkjihgfedcba'
+
+    @lru_cache(1)
+    def jumble_map(self) -> Dict[str, str]:
+        return {jc: nc for jc, nc in zip(self.jumble_char_set, self.normal_char_set)}
+
+    @staticmethod
+    def reorder_text(jumble_map, element):
+        text = ''
+        for char in element.text:
+            try:
+                text += jumble_map[char]
+            except KeyError:
+                text += char
+
+        element.string = text
+
+        return element

--- a/novelsave_sources/sources/novel/dragontea.py
+++ b/novelsave_sources/sources/novel/dragontea.py
@@ -9,11 +9,9 @@ class DragonTea(Source):
     base_urls = ('https://dragontea.ink/',)
     last_updated = datetime.date(2021, 9, 7)
 
-    bad_tags = [
-        'noscript', 'script', 'iframe', 'form', 'hr', 'img', 'ins',
-        'button', 'input', 'amp-auto-ads', 'pirate',
-        'h1', 'h2', 'h3', 'h4', 'h5', 'h6',
-    ]
+    def __init__(self):
+        super(DragonTea, self).__init__()
+        self.bad_tags += ['h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'hr']
 
     def novel(self, url: str) -> Novel:
         http_url = url.replace('https:', 'http:')

--- a/novelsave_sources/sources/novel/dragontea.py
+++ b/novelsave_sources/sources/novel/dragontea.py
@@ -16,7 +16,8 @@ class DragonTea(Source):
     ]
 
     def novel(self, url: str) -> Novel:
-        soup = self.get_soup(url)
+        http_url = url.replace('https:', 'http:')
+        soup = self.get_soup(http_url)
 
         novel = Novel(
             title=soup.select_one('.post-title').text.strip(),
@@ -45,7 +46,7 @@ class DragonTea(Source):
         if artist_content:
             novel.metadata.append(Metadata('contributor', artist_content.text.strip(), others={'role': 'ill'}))
 
-        soup = self.get_soup(url.rstrip('/') + '/ajax/chapters/', method='POST')
+        soup = self.get_soup(http_url.rstrip('/') + '/ajax/chapters/', method='POST')
         volume = novel.get_default_volume()
         for a in reversed(soup.select('.wp-manga-chapter > a')):
             chapter = Chapter(


### PR DESCRIPTION
- Converted https://dragontea.ink connections to `http` due to `certifi` limitations
- Unjumble the paragraphs without using fonts
  - As a side-effect, removes any styling `b` `stong` that may be present
- Remove `<hr>` elements from https://dragontea.ink